### PR TITLE
Add OnePlus 13, OnePlus Ace 5 Pro and OnePlus Pad 2 Support and optimisations

### DIFF
--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -1,9 +1,9 @@
 name: Build and Release OnePlus Kernels
 
 permissions:
-  contents: write  # Allow writing to repository contents (for pushing tags)
-  actions: write   # Allows triggering actions
-  
+  contents: write
+  actions: write
+
 on:
   workflow_dispatch:
     inputs:
@@ -14,146 +14,141 @@ on:
         default: true
 
 jobs:
-  build-kernel-op11:
+  build-batch-1: # Non Bazel Builds
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - model: OP11
+            soc: kalama
+            branch: oneplus/sm8550
+            manifest: oneplus_11_v.xml
+            android_version: android13
+            kernel_version: "5.15"
+          - model: OP11r
+            soc: waipio
+            branch: oneplus/sm8475
+            manifest: oneplus_11r_v.xml
+            android_version: android13
+            kernel_version: "5.10"
+          - model: OP-OPEN
+            soc: kalama
+            branch: oneplus/sm8550
+            manifest: oneplus_open_v.xml
+            android_version: android13
+            kernel_version: "5.15"
+          - model: OP-ACE-2
+            soc: waipio
+            branch: oneplus/sm8475
+            manifest: oneplus_ace2_v.xml
+            android_version: android13
+            kernel_version: "5.10"
+          - model: OP10t
+            soc: waipio
+            branch: oneplus/sm8475
+            manifest: oneplus_10t_v.xml
+            android_version: android12
+            kernel_version: "5.10"
+          - model: OP10pro
+            soc: waipio
+            branch: oneplus/sm8450
+            manifest: oneplus_10_pro_v.xml
+            android_version: android12
+            kernel_version: "5.10"
+          - model: OP-ACE-2-PRO
+            soc: kalama
+            branch: oneplus/sm8550
+            manifest: oneplus_ace2pro_v.xml
+            android_version: android13
+            kernel_version: "5.15"
     uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
-      model: "OP11"
-      soc: "kalama"
-      branch: "oneplus/sm8550"
-      manifest: "oneplus_11_v.xml"
-      android_version: "android13"
-      kernel_version: "5.15"
-  build-kernel-op11r:
+      model: ${{ matrix.model }}
+      soc: ${{ matrix.soc }}
+      branch: ${{ matrix.branch }}
+      manifest: ${{ matrix.manifest }}
+      android_version: ${{ matrix.android_version }}
+      kernel_version: ${{ matrix.kernel_version }}
+
+  build-batch-2:
+    # needs: build-batch-1
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - model: OP13
+            soc: sun
+            branch: oneplus/sm8750
+            manifest: oneplus_13.xml
+            android_version: android15
+            kernel_version: "6.6"
+          - model: OPAce5Pro
+            soc: sun
+            branch: oneplus/sm8750
+            manifest: oneplus_ace5_pro.xml
+            android_version: android15
+            kernel_version: "6.6"
+          - model: OP12
+            soc: pineapple
+            branch: oneplus/sm8650
+            manifest: oneplus12_v.xml
+            android_version: android14
+            kernel_version: "6.1"
+          - model: OP13r
+            soc: pineapple
+            branch: oneplus/sm8650
+            manifest: oneplus_13r.xml
+            android_version: android14
+            kernel_version: "6.1"
+          - model: OP-ACE-5
+            soc: pineapple
+            branch: oneplus/sm8650
+            manifest: oneplus_ace5.xml
+            android_version: android14
+            kernel_version: "6.1"
+          - model: OP-NORD-4
+            soc: pineapple
+            branch: oneplus/sm7675
+            manifest: oneplus_nord_4_v.xml
+            android_version: android14
+            kernel_version: "6.1"
+          - model: OP-PAD-2
+            soc: pineapple
+            branch: oneplus/sm8650
+            manifest: oneplus_pad2_v.xml
+            android_version: android14
+            kernel_version: "6.1"
     uses: ./.github/workflows/build.yml
     secrets: inherit
     with:
-      model: "OP11r"
-      soc: "waipio"
-      branch: "oneplus/sm8475"
-      manifest: "oneplus_11r_v.xml"
-      android_version: "android13"
-      kernel_version: "5.10"
-  build-kernel-op12:
-    uses: ./.github/workflows/build.yml
-    secrets: inherit
-    with:
-      model: "OP12"
-      soc: "pineapple"
-      branch: "oneplus/sm8650"
-      manifest: "oneplus12_v.xml"
-      android_version: "android14"
-      kernel_version: "6.1"
-  build-kernel-op13r:
-    uses: ./.github/workflows/build.yml
-    secrets: inherit
-    with:
-      model: "OP13r"
-      soc: "pineapple"
-      branch: "oneplus/sm8650"
-      manifest: "oneplus_13r.xml"
-      android_version: "android14"
-      kernel_version: "6.1"
-  build-kernel-opnord4:
-    uses: ./.github/workflows/build.yml
-    secrets: inherit
-    with:
-      model: "OP-NORD-4"
-      soc: "pineapple"
-      branch: "oneplus/sm7675"
-      manifest: "oneplus_nord_4_v.xml"
-      android_version: "android14"
-      kernel_version: "6.1"
-  build-kernel-opopen:
-    uses: ./.github/workflows/build.yml
-    secrets: inherit
-    with:
-      model: "OP-OPEN"
-      soc: "kalama"
-      branch: "oneplus/sm8550"
-      manifest: "oneplus_open_v.xml"
-      android_version: "android13"
-      kernel_version: "5.15"
-  build-kernel-opace2:
-    uses: ./.github/workflows/build.yml
-    secrets: inherit
-    with:
-      model: "OP-ACE-2"
-      soc: "waipio"
-      branch: "oneplus/sm8475"
-      manifest: "oneplus_ace2_v.xml"
-      android_version: "android13"
-      kernel_version: "5.10"
-  build-kernel-opace2pro:
-    uses: ./.github/workflows/build.yml
-    secrets: inherit
-    with:
-      model: "OP-ACE-2-PRO"
-      soc: "kalama"
-      branch: "oneplus/sm8550"
-      manifest: "oneplus_ace2pro_v.xml"
-      android_version: "android13"
-      kernel_version: "5.15"
-  build-kernel-opace5:
-    uses: ./.github/workflows/build.yml
-    secrets: inherit
-    with:
-      model: "OP-ACE-5"
-      soc: "pineapple"
-      branch: "oneplus/sm8650"
-      manifest: "oneplus_ace5.xml"
-      android_version: "android14"
-      kernel_version: "6.1"
-  build-kernel-op10t:
-    uses: ./.github/workflows/build.yml
-    secrets: inherit
-    with:
-      model: "OP10t"
-      soc: "waipio"
-      branch: "oneplus/sm8475"
-      manifest: "oneplus_10t_v.xml"
-      android_version: "android12"
-      kernel_version: "5.10"
-  build-kernel-op10pro:
-    uses: ./.github/workflows/build.yml
-    secrets: inherit
-    with:
-      model: "OP10pro"
-      soc: "waipio"
-      branch: "oneplus/sm8450"
-      manifest: "oneplus_10_pro_v.xml"
-      android_version: "android12"
-      kernel_version: "5.10"
+      model: ${{ matrix.model }}
+      soc: ${{ matrix.soc }}
+      branch: ${{ matrix.branch }}
+      manifest: ${{ matrix.manifest }}
+      android_version: ${{ matrix.android_version }}
+      kernel_version: ${{ matrix.kernel_version }}
 
   trigger-release:
-    runs-on: ubuntu-latest
     needs:
-        - build-kernel-op11
-        - build-kernel-op11r
-        - build-kernel-op12
-        - build-kernel-op13r
-        - build-kernel-opnord4
-        - build-kernel-opopen
-        - build-kernel-opace2
-        - build-kernel-opace2pro
-        - build-kernel-opace5
-        - build-kernel-op10t
-        - build-kernel-op10pro
+      - build-batch-1
+      - build-batch-2
+    runs-on: ubuntu-latest
     if: ${{ inputs.make_release }}
     env:
-      REPO_OWNER: TheWildJames
-      REPO_NAME: OnePlus_KernelSU_SUSFS
+      REPO_OWNER: ${{ github.repository_owner }}
+      REPO_NAME: ${{ github.event.repository.name }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       RELEASE_NAME: "*TEST BUILD* OnePlus Kernels With KernelSU Next & SUSFS v1.5.5 *TEST BUILD*"
       RELEASE_NOTES: |
         This release contains KernelSU Next and SUSFS v1.5.5
-        
+
         Module: 
         -> https://github.com/sidex15/ksu_module_susfs
-        
+
         Non-Official Managers:
         -> https://github.com/KernelSU-Next/KernelSU-Next
-        
+
         Features:
         [+] KernelSU-Next
         [+] SUSFS v1.5.5
@@ -163,59 +158,42 @@ jobs:
         [+] Magic Mount Support
 
     steps:
-      # Checkout the code
       - name: Checkout code
         uses: actions/checkout@v3
 
-      # Get the Latest Tag from GitHub
       - name: Generate and Create New Tag
         run: |
-            # Fetch the latest tag from GitHub (this is the latest tag based on the GitHub API)
             LATEST_TAG=$(gh api repos/$REPO_OWNER/$REPO_NAME/tags --jq '.[0].name')
             if [ -z "$LATEST_TAG" ]; then
-              LATEST_TAG="v1.5.5-r0"  # Default to v1.5.3-0 if no tag exists
+              LATEST_TAG="v1.5.5-r0"
             fi
-            
-            # Increment the suffix (e.g., v1.5.3-0 becomes v1.5.3-1)
             NEW_TAG=$(echo "$LATEST_TAG" | awk -F'-r' '{suffix=$2; if (!suffix) suffix=0; suffix++; printf "%s-r%d", $1, suffix}')
-            
-            # Output the new tag to be used
             echo "New tag: $NEW_TAG"
-            
-            # Set the new tag as an environment variable to be used in later steps
             echo "NEW_TAG=${NEW_TAG}" >> $GITHUB_ENV
-            
-            # Create the tag in the repository
             git tag $NEW_TAG
             git push origin $NEW_TAG
-            
-      # Download Artifacts for A12 (Only if A12 Build is successful or input is true or empty)
+
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
           path: ./downloaded-artifacts
 
-      # Create GitHub Release and upload files if make_release is true
       - name: Create GitHub Release
         uses: actions/create-release@v1
         with:
-          tag_name: ${{ env.NEW_TAG }}  # Use the generated tag for the release
-          prerelease: true  # Mark the release as a pre-release
-          release_name: ${{ env.RELEASE_NAME }}  # Pass the RELEASE_NAME to the action
-          body: ${{ env.RELEASE_NOTES }}  # Pass the RELEASE_NOTES to the action
+          tag_name: ${{ env.NEW_TAG }}
+          prerelease: true
+          release_name: ${{ env.RELEASE_NAME }}
+          body: ${{ env.RELEASE_NOTES }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload Release Assets Dynamically
         run: |
-          # Loop through all files in the downloaded-artifacts directory
           for file in ./downloaded-artifacts/kernel-*/*; do
-              # Skip directories
               if [ -d "$file" ]; then
                   continue
               fi
-
-              # Upload the file to the GitHub release
               echo "Uploading $file..."
               gh release upload ${{ env.NEW_TAG }} "$file"
           done
@@ -223,7 +201,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NEW_TAG: ${{ env.NEW_TAG }}
 
-      # Display Files Uploaded
       - name: Display Files Uploaded
         run: |
           echo "GitHub release created with the following files:"

--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -12,9 +12,20 @@ on:
         required: true
         type: boolean
         default: true
+      ksun_branch:
+        description: "Choose KernelSU Next Branch"
+        required: true
+        type: choice
+        options:
+          - stable
+          - next
+          - next-susfs
+          - next-susfs-dev
+        default: stable
 
 jobs:
   build-batch-1: # Non Bazel Builds
+    name: build-batch-1 (${{ matrix.model }}, ${{ matrix.soc }}, ${{ matrix.branch }}, ${{ matrix.manifest }}, ${{ matrix.android_version }}, ${{ matrix.kernel_version }}, ${{ inputs.ksun_branch }})
     strategy:
       fail-fast: false
       matrix:
@@ -70,9 +81,11 @@ jobs:
       manifest: ${{ matrix.manifest }}
       android_version: ${{ matrix.android_version }}
       kernel_version: ${{ matrix.kernel_version }}
+      ksun_branch: ${{ inputs.ksun_branch }}
 
   build-batch-2:
     # needs: build-batch-1
+    name: build-batch-2 (${{ matrix.model }}, ${{ matrix.soc }}, ${{ matrix.branch }}, ${{ matrix.manifest }}, ${{ matrix.android_version }}, ${{ matrix.kernel_version }}, ${{ inputs.ksun_branch }})
     strategy:
       fail-fast: false
       matrix:
@@ -128,6 +141,7 @@ jobs:
       manifest: ${{ matrix.manifest }}
       android_version: ${{ matrix.android_version }}
       kernel_version: ${{ matrix.kernel_version }}
+      ksun_branch: ${{ inputs.ksun_branch }}
 
   trigger-release:
     needs:
@@ -139,10 +153,10 @@ jobs:
       REPO_OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      RELEASE_NAME: "*TEST BUILD* OnePlus Kernels With KernelSU Next & SUSFS v1.5.5 *TEST BUILD*"
+      RELEASE_NAME: "*TEST BUILD* OnePlus Kernels With KernelSU Next & SUSFS v1.5.7 *TEST BUILD*"
       RELEASE_NOTES: |
-        This release contains KernelSU Next and SUSFS v1.5.5
-
+        This release contains KernelSU Next and SUSFS v1.5.7
+        
         Module: 
         -> https://github.com/sidex15/ksu_module_susfs
 
@@ -151,7 +165,7 @@ jobs:
 
         Features:
         [+] KernelSU-Next
-        [+] SUSFS v1.5.5
+        [+] SUSFS v1.5.7
         [+] Wireguard Support
         [+] Maphide LineageOS Detections
         [+] Futile Maphide for jit-zygote-cache Detections
@@ -165,7 +179,7 @@ jobs:
         run: |
             LATEST_TAG=$(gh api repos/$REPO_OWNER/$REPO_NAME/tags --jq '.[0].name')
             if [ -z "$LATEST_TAG" ]; then
-              LATEST_TAG="v1.5.5-r0"
+              LATEST_TAG="v1.5.7-r0"
             fi
             NEW_TAG=$(echo "$LATEST_TAG" | awk -F'-r' '{suffix=$2; if (!suffix) suffix=0; suffix++; printf "%s-r%d", $1, suffix}')
             echo "New tag: $NEW_TAG"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,11 @@ on:
       kernel_version:
         required: true
         type: string
-  
+      ksun_branch:
+        required: true
+        type: string
+        default: stable
+
 jobs:
   build-kernel-oneplus-kernelsu-susfs:
     runs-on: ubuntu-latest
@@ -89,11 +93,11 @@ jobs:
           
           ANYKERNEL_BRANCH="gki-2.0"
           SUSFS_BRANCH="gki-${{ inputs.android_version }}-${{ inputs.kernel_version }}"
-
+          
           # Debug print the branches
           echo "Using branch for AnyKernel3: $ANYKERNEL_BRANCH"
           echo "Using branch for SUSFS: $SUSFS_BRANCH"
-
+          
           # Clone repositories using the branch names
           git clone https://github.com/TheWildJames/AnyKernel3.git -b "$ANYKERNEL_BRANCH"
           git clone https://gitlab.com/simonpunk/susfs4ksu.git -b "$SUSFS_BRANCH"
@@ -113,19 +117,20 @@ jobs:
           $REPO --version
           $REPO --trace sync -c --no-clone-bundle --no-tags --optimized-fetch -j$(nproc --all) --fail-fast
       
-      - name: Add KernelSU
+      - name: Add KernelSU Next
         run: |
           echo "Changing to configuration directory: $CONFIG..."
           cd "$CONFIG/kernel_platform"
           
-          echo "Adding KernelSU..."
-          curl -LSs "https://raw.githubusercontent.com/KernelSU-Next/KernelSU-Next/next/kernel/setup.sh" | bash -s next
+          echo "Adding KernelSU Next..."
+          
+          if [ "${{ inputs.ksun_branch }}" == "stable" ]; then
+            curl -LSs "https://raw.githubusercontent.com/KernelSU-Next/KernelSU-Next/next/kernel/setup.sh" | bash -
+          else
+            curl -LSs "https://raw.githubusercontent.com/KernelSU-Next/KernelSU-Next/next/kernel/setup.sh" | bash -s ${{ inputs.ksun_branch }}
+          fi
           
           git submodule update --init --recursive
-          cd KernelSU-Next/kernel
-          KSU_VERSION=$(expr $(/usr/bin/git rev-list --count HEAD) "+" 10200)
-          echo "KSUVER=$KSU_VERSION" >> $GITHUB_ENV
-          sed -i "s/DKSU_VERSION=11998/DKSU_VERSION=${KSU_VERSION}/" Makefile
 
       - name: Apply SUSFS Patches
         run: |
@@ -141,22 +146,42 @@ jobs:
           
           cd ./KernelSU-Next
           
-          echo "Applying next SUSFS patches..."
-          cp ../../../kernel_patches/next/0001-kernel-patch-susfs-v1.5.5-to-KernelSU-Next-v1.0.5.patch ./
-          patch -p1 --forward < 0001-kernel-patch-susfs-v1.5.5-to-KernelSU-Next-v1.0.5.patch || true
+          if [ "${{ inputs.ksun_branch }}" == "stable" ] || [ "${{ inputs.ksun_branch }}" == "next" ]; then
+            echo "Applying next SUSFS patches..."
+            cp ../../../kernel_patches/next/kernel-patch-susfs-v1.5.7-to-KernelSU-Next.patch ./ksun_susfs_latest.patch
+            patch -p1 --forward < ksun_susfs_latest.patch || true
+          fi
+          
+          # Determine base version based on branch
+          if [ "${{ inputs.ksun_branch }}" == "stable" ]; then
+            BASE_VERSION=10200
+          elif [ "${{ inputs.ksun_branch }}" == "next" ]; then
+            BASE_VERSION=10200
+          elif [ "${{ inputs.ksun_branch }}" == "next-susfs" ]; then
+            BASE_VERSION=10198
+          elif [ "${{ inputs.ksun_branch }}" == "next-susfs-dev" ]; then
+            BASE_VERSION=10198
+          else
+            BASE_VERSION=10200
+          fi
+          
+          cd ./kernel
+          KSU_VERSION=$(expr $(/usr/bin/git rev-list --count HEAD) "+" $BASE_VERSION)
+          echo "KSUVER=$KSU_VERSION" >> $GITHUB_ENV
+          sed -i "s/DKSU_VERSION=11998/DKSU_VERSION=${KSU_VERSION}/" Makefile
           
           # Change to common directory and apply SUSFS patch
-          cd ../common
+          cd ../../common
           if [ "${{ inputs.soc }}" == "sun" ]; then
             sed -i '/#include <trace\/hooks\/blk.h>/a #include <trace/hooks/fs.h>' ./fs/namespace.c
           fi
           patch -p1 < 50_add_susfs_in_gki-${{ inputs.android_version }}-${{ inputs.kernel_version }}.patch || true
 
-      - name: Apply KSU Hooks
+      - name: Apply KSUN Hooks
         run: |
           echo "Changing to configuration directory: $CONFIG..."
           cd "$CONFIG/kernel_platform/common"
-          # Apply additional patch
+          echo "Applying KSUN Hooks..."
           cp ../../../kernel_patches/next/syscall_hooks.patch ./
           patch -p1 --fuzz=3 < ./syscall_hooks.patch
           
@@ -174,7 +199,7 @@ jobs:
           cd "$CONFIG/kernel_platform"
           
           echo "Adding configuration settings to gki_defconfig..."
-
+          
           # Add KSU configuration settings
           echo "CONFIG_KSU=y" >> ./common/arch/arm64/configs/gki_defconfig
           echo "CONFIG_KSU_WITH_KPROBES=n" >> ./common/arch/arm64/configs/gki_defconfig
@@ -207,22 +232,22 @@ jobs:
           cd "$CONFIG/kernel_platform"
           
           echo "Running sed commands..."
-
+          
           sed -i 's/CONFIG_LTO=n/CONFIG_LTO=y/' "./common/arch/arm64/configs/gki_defconfig"
           sed -i 's/CONFIG_LTO_CLANG_FULL=y/CONFIG_LTO_CLANG_THIN=y/' "./common/arch/arm64/configs/gki_defconfig"
           sed -i 's/CONFIG_LTO_CLANG_NONE=y/CONFIG_LTO_CLANG_THIN=y/' "./common/arch/arm64/configs/gki_defconfig"
           
           # Run sed commands for modifications
           sed -i 's/check_defconfig//' ./common/build.config.gki
-          sed -i '$s|echo "\$res"|echo "\$res-Wild+"|' ./common/scripts/setlocalversion
-          sed -i '$s|echo "\$res"|echo "\$res-Wild+"|' ./msm-kernel/scripts/setlocalversion
-          sed -i '$s|echo "\$res"|echo "\$res-Wild+"|' ./external/dtc/scripts/setlocalversion
+          sed -i '$s|echo "\$res"|echo "\$res-Wild"|' ./common/scripts/setlocalversion
+          sed -i '$s|echo "\$res"|echo "\$res-Wild"|' ./msm-kernel/scripts/setlocalversion
+          sed -i '$s|echo "\$res"|echo "\$res-Wild"|' ./external/dtc/scripts/setlocalversion
           sed -i "/stable_scmversion_cmd/s/-maybe-dirty//g" ./build/kernel/kleaf/impl/stamp.bzl || echo "No stamp.bzl!"
           sed -i 's/-dirty//' ./common/scripts/setlocalversion
           sed -i 's/-dirty//' ./msm-kernel/scripts/setlocalversion
           sed -i 's/-dirty//' ./external/dtc/scripts/setlocalversion
           sed -i 's/-dirty//' ./build/kernel/kleaf/workspace_status_stamp.py || echo "No workspace_status_stamp.py!"
-
+          
           sed -i '/echo "LTO $LTO "/i export LTO=thin' ./oplus/build/oplus_setup.sh
           sed -i 's/export REPACK_IMG=true/export REPACK_IMG=false/g' ./oplus/build/oplus_setup.sh
          
@@ -277,7 +302,7 @@ jobs:
         run: |
           echo "Changing to configuration directory: $CONFIG..."
           cd "$CONFIG"
-
+          
           echo "Copying Image"
           cp ./out/dist/Image ../AnyKernel3/Image
           if [ "${{ inputs.model }}" == "OPAce5Pro" ]; then
@@ -291,7 +316,7 @@ jobs:
         run: |
           echo "Navigating to AnyKernel3 directory..."
           cd ./AnyKernel3
-
+          
           # Zip the files in the AnyKernel3 directory with a new naming convention
           ZIP_NAME="${{ inputs.model }}_${{ inputs.android_version }}_${{ inputs.kernel_version }}_Next_SUSFS_AnyKernel3.zip"
           echo "Creating zip file $ZIP_NAME..."

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,22 +30,49 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Maximize build space
-        uses: easimon/maximize-build-space@master
-        with:
-          root-reserve-mb: 8192
-          temp-reserve-mb: 2048
-          swap-size-mb: 8192
-          remove-dotnet: 'true'
-          remove-android: 'true'
-          remove-haskell: 'true'
-          remove-codeql: 'true'
+      - name: Setup System
+        run: |
+          export DEBIAN_FRONTEND=noninteractive
+          echo "DEBIAN_FRONTEND=noninteractive" >> $GITHUB_ENV
+          
+          df -h
+          
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL /usr/local/share/powershell /usr/share/swift || true
+          sudo docker image prune --all --force
+          echo "some directories deleted"
+          
+          # Remove large unwanted packages
+          sudo apt-get purge -y \
+            aria2 ansible azure-cli shellcheck rpm xorriso zsync \
+            esl-erlang firefox gfortran-8 gfortran-9 google-chrome-stable \
+            google-cloud-sdk imagemagick \
+            libmagickcore-dev libmagickwand-dev libmagic-dev ant ant-optional kubectl \
+            mercurial apt-transport-https mono-complete libmysqlclient \
+            unixodbc-dev yarn chrpath libssl-dev libxft-dev \
+            libfreetype6 libfreetype6-dev libfontconfig1 libfontconfig1-dev \
+            snmp pollinate libpq-dev postgresql-client powershell ruby-full \
+            sphinxsearch subversion mongodb-org microsoft-edge-stable || true
+          
+          # Regex-based purges (for bulk families like mysql, php, dotnet)
+          sudo apt-get purge -y $(dpkg-query -W -f='${binary:Package}\n' | grep -E '^mysql|^php|^dotnet') || true
+          
+          # Clean up
+          sudo apt-get autoremove -y
+          sudo apt-get autoclean -y
+          echo "some packages purged"
+          
+          df -h
 
       - name: Install Repo and Python
         run: |
           # Install dependencies
           sudo apt update
-          sudo apt install repo python3 python-is-python3
+          sudo apt install -y python3 python-is-python3
+          
+          mkdir -p ./git-repo
+          curl -sSL https://storage.googleapis.com/git-repo-downloads/repo > ./git-repo/repo
+          chmod a+rx ./git-repo/repo
+          echo "REPO=$GITHUB_WORKSPACE/./git-repo/repo" >> $GITHUB_ENV
 
       - name: Set CONFIG Environment Variable
         run: |
@@ -80,11 +107,11 @@ jobs:
           
           # Initialize and sync kernel source
           echo "Initializing and syncing kernel source..."
-          repo init -u https://github.com/OnePlusOSS/kernel_manifest.git -b ${{ inputs.branch }} -m ${{ inputs.manifest }} --repo-rev=v2.16 --depth=1
+          $REPO init -u https://github.com/OnePlusOSS/kernel_manifest.git -b ${{ inputs.branch }} -m ${{ inputs.manifest }} --repo-rev=v2.16 --depth=1 --no-clone-bundle --no-tags
           
           # Sync repo and apply patches
-          repo --version
-          repo --trace sync -c -j$(nproc --all) --no-tags --fail-fast
+          $REPO --version
+          $REPO --trace sync -c --no-clone-bundle --no-tags --optimized-fetch -j$(nproc --all) --fail-fast
       
       - name: Add KernelSU
         run: |
@@ -92,11 +119,13 @@ jobs:
           cd "$CONFIG/kernel_platform"
           
           echo "Adding KernelSU..."
-          curl -LSs "https://raw.githubusercontent.com/rifsxd/KernelSU-Next/next/kernel/setup.sh" | bash -s next
-          #cd ./KernelSU-Next/kernel
-          #sed -i 's/ccflags-y += -DKSU_VERSION=16/ccflags-y += -DKSU_VERSION=12000/' ./Makefile
-          KSU_VERSION=$(cd ./KernelSU-Next/kernel && git describe --tags --abbrev=0)
-          echo "KSUVER=${KSU_VERSION}" >> $GITHUB_ENV
+          curl -LSs "https://raw.githubusercontent.com/KernelSU-Next/KernelSU-Next/next/kernel/setup.sh" | bash -s next
+          
+          git submodule update --init --recursive
+          cd KernelSU-Next/kernel
+          KSU_VERSION=$(expr $(/usr/bin/git rev-list --count HEAD) "+" 10200)
+          echo "KSUVER=$KSU_VERSION" >> $GITHUB_ENV
+          sed -i "s/DKSU_VERSION=11998/DKSU_VERSION=${KSU_VERSION}/" Makefile
 
       - name: Apply SUSFS Patches
         run: |
@@ -109,7 +138,7 @@ jobs:
           cp ../../susfs4ksu/kernel_patches/50_add_susfs_in_gki-${{ inputs.android_version }}-${{ inputs.kernel_version }}.patch ./common/
           cp ../../susfs4ksu/kernel_patches/fs/* ./common/fs/
           cp ../../susfs4ksu/kernel_patches/include/linux/* ./common/include/linux/
-
+          
           cd ./KernelSU-Next
           
           echo "Applying next SUSFS patches..."
@@ -118,6 +147,9 @@ jobs:
           
           # Change to common directory and apply SUSFS patch
           cd ../common
+          if [ "${{ inputs.soc }}" == "sun" ]; then
+            sed -i '/#include <trace\/hooks\/blk.h>/a #include <trace/hooks/fs.h>' ./fs/namespace.c
+          fi
           patch -p1 < 50_add_susfs_in_gki-${{ inputs.android_version }}-${{ inputs.kernel_version }}.patch || true
 
       - name: Apply KSU Hooks
@@ -125,8 +157,8 @@ jobs:
           echo "Changing to configuration directory: $CONFIG..."
           cd "$CONFIG/kernel_platform/common"
           # Apply additional patch
-          cp ../../../kernel_patches/next/next_hooks.patch ./
-          patch -p1 --fuzz=3 < ./next_hooks.patch
+          cp ../../../kernel_patches/next/syscall_hooks.patch ./
+          patch -p1 --fuzz=3 < ./syscall_hooks.patch
           
       - name: Apply Hide Stuff Patches
         run: |
@@ -195,8 +227,10 @@ jobs:
           sed -i 's/export REPACK_IMG=true/export REPACK_IMG=false/g' ./oplus/build/oplus_setup.sh
          
           # Run perl command to modify UTS_VERSION
-          perl -pi -e 's{UTS_VERSION="\$\(echo \$UTS_VERSION \$CONFIG_FLAGS \$TIMESTAMP \| cut -b -\$UTS_LEN\)"}{UTS_VERSION="#1 SMP PREEMPT Sat Apr 20 04:20:00 UTC 2024"}' ./common/scripts/mkcompile_h
-          perl -pi -e 's{UTS_VERSION="\$\(echo \$UTS_VERSION \$CONFIG_FLAGS \$TIMESTAMP \| cut -b -\$UTS_LEN\)"}{UTS_VERSION="#1 SMP PREEMPT Sat Apr 20 04:20:00 UTC 2024"}' ./msm-kernel/scripts/mkcompile_h
+          perl -pi -e 's{UTS_VERSION="\$\(echo \$UTS_VERSION \$CONFIG_FLAGS \$TIMESTAMP \| cut -b -\$UTS_LEN\)"}{UTS_VERSION="#1 SMP PREEMPT Thu Mar 05 04:20:00 UTC 2025"}' ./common/scripts/mkcompile_h
+          perl -pi -e 's{UTS_VERSION="\$\(echo \$UTS_VERSION \$CONFIG_FLAGS \$TIMESTAMP \| cut -b -\$UTS_LEN\)"}{UTS_VERSION="#1 SMP PREEMPT Thu Mar 05 04:20:00 UTC 2025"}' ./msm-kernel/scripts/mkcompile_h
+          
+          find . -type f -exec sed -i 's/\(make\s\+-C[^\n]*\)\s\+/\1 -j$(nproc) /g' {} +
 
       - name: Build the Kernel
         run: |
@@ -204,24 +238,39 @@ jobs:
           cd "$CONFIG"
           
           echo "Building the kernel..."
+          # Clear Cache
+          sudo sh -c 'sync; echo 3 > /proc/sys/vm/drop_caches'
+          
           rm ./kernel_platform/common/android/abi_gki_protected_exports_* || echo "No protected exports!"
           rm ./kernel_platform/msm-kernel/android/abi_gki_protected_exports_* || echo "No protected exports!"
-          #git config --global user.email "bins4us@hotmail.com"
-          #git config --global user.name "TheWildJames"
-          #git add *
-          #git commit -s -a -m "getting rid of -dirty"
+          
+          BUILD_TYPE="gki"
+          BAZEL_ARGS=(--jobs=$(nproc --all) --lto=thin)
+          if [ "${{ inputs.soc }}" == "sun" ]; then
+            BUILD_TYPE="perf"
+            BAZEL_ARGS+=(-g)
+          fi
+          
+          (stdbuf -oL bash -c '
+            while true; do
+              echo "=== $(date) ==="
+              free -h
+              echo "======"
+              df -h
+              echo "======"
+              top -b -n 1 | head -n 15
+              echo ""
+              sleep 60
+            done
+          ') &
+          MONITOR_PID=$!
+          trap "kill $MONITOR_PID" EXIT
+          
           if [ -f ./kernel_platform/build_with_bazel.py ]; then
-            ./kernel_platform/build_with_bazel.py \
-              -t ${{ inputs.soc }} \
-              gki \
-              --jobs=$(nproc --all) \
-              --verbose_failures \
-              --config=stamp \
-              --user_kmi_symbol_lists=//msm-kernel:android/abi_gki_aarch64_qcom \
-              --ignore_missing_projects \
-              -o "$(pwd)/out"
+            ./kernel_platform/oplus/bazel/oplus_modules_variant.sh ${{ inputs.soc }} "$BUILD_TYPE" ""
+            ./kernel_platform/build_with_bazel.py -t ${{ inputs.soc }} $BUILD_TYPE "${BAZEL_ARGS[@]}" -o "$(pwd)/out"
           else
-            ./kernel_platform/oplus/build/oplus_build_kernel.sh ${{ inputs.soc }} gki
+            LTO=thin ./kernel_platform/oplus/build/oplus_build_kernel.sh ${{ inputs.soc }} "$BUILD_TYPE"
           fi
 
       - name: Copy Images
@@ -231,6 +280,12 @@ jobs:
 
           echo "Copying Image"
           cp ./out/dist/Image ../AnyKernel3/Image
+          if [ "${{ inputs.model }}" == "OPAce5Pro" ]; then
+            cp ./out/dist/dtbo.img ../AnyKernel3/
+            cp ./out/dist/system_dlkm.erofs.img ../AnyKernel3/system_dlkm.img
+            # cp ./out/dist/vendor_dlkm.img ../AnyKernel3/
+            # cp ./out/dist/vendor_boot.img ../AnyKernel3/
+          fi
 
       - name: Create ZIP Files for Different Formats
         run: |
@@ -241,7 +296,12 @@ jobs:
           ZIP_NAME="${{ inputs.model }}_${{ inputs.android_version }}_${{ inputs.kernel_version }}_Next_SUSFS_AnyKernel3.zip"
           echo "Creating zip file $ZIP_NAME..."
           zip -r "../$ZIP_NAME" ./*
-          
+          # Fengchi Patch for OPAce5Pro
+          if [ "${{ inputs.model }}" == "OPAce5Pro" ]; then
+            sed -i 's/hmbird/xxbird/g' dtbo.img
+            zip -r "../$ZIP_NAME-CN-version.zip" ./*
+          fi
+
       - name: Upload Build Artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
- Added support for OnePlus 13, OnePlus Ace 5 Pro and OnePlus Pad 2.
- Replaced maximize-build-space with manual commands to reduce overhead from LVM and finer control.
- Replaced multiple jobs with matrix strategy.
- Added resource monitoring during build.
- Updated Bazel build args.
- Fix the KSU Version Number issue.
- Using Official Manifest.
- Add Fengchi Patch for OP Ace 5 Pro
- Update to Syscall Hook.
- Update Release REPO_NAME and REPO_OWNER to be dynamic.

Thanks to @Bouteillepleine for the KSU Version Number issue fix.

Some of the builds have been tested
Bazel Builds:
OP13: Tested by @omer-1080314 and by other users on Telegram
OP Ace 5 Pro: This was tested by a user on Telegram, but on OP13 and not an actual device.
OP12: Tested by @FerGus786

Non-Bazel Builds:
OP11: I have tested this device.

Build Run Details:
[RUN 1](https://github.com/fatalcoder524/OnePlus_KernelSU_SUSFS/actions/runs/14395164347)
[RUN 2](https://github.com/fatalcoder524/OnePlus_KernelSU_SUSFS/actions/runs/14395165477)
[RUN 3](https://github.com/fatalcoder524/OnePlus_KernelSU_SUSFS/actions/runs/14395166213)
[RUN 4](https://github.com/fatalcoder524/OnePlus_KernelSU_SUSFS/actions/runs/14439830861) [Official Manifest]
[RUN 5](https://github.com/fatalcoder524/OnePlus_KernelSU_SUSFS/actions/runs/14537988270) [Fengchi Patch + Dynamic Repo Release]
[RUN 6](https://github.com/fatalcoder524/OnePlus_KernelSU_SUSFS/actions/runs/14552465096) [OP Pad 2 Support]