### PR TITLE
Add Support for OnePlus 12r and fix wrong android version for OnePlus 11r

### DIFF
--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -72,6 +72,12 @@ jobs:
             manifest: oneplus_ace2pro_v.xml
             android_version: android13
             kernel_version: "5.15"
+          - model: OP12r
+            soc: kalama
+            branch: oneplus/sm8550
+            manifest: oneplus_12r_v.xml
+            android_version: android13
+            kernel_version: "5.15"
     uses: ./.github/workflows/build.yml
     secrets: inherit
     with:

--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -40,7 +40,7 @@ jobs:
             soc: waipio
             branch: oneplus/sm8475
             manifest: oneplus_11r_v.xml
-            android_version: android13
+            android_version: android12
             kernel_version: "5.10"
           - model: OP-OPEN
             soc: kalama


### PR DESCRIPTION
The OnePlus 12r Kernel has been tested by the user who requested it, and it works fine!

The Android version of OnePlus 11r is updated from android13 to android12. Verfied by user reports and build.config.common file.