### PR TITLE
Add global manifest for OP13 global model

### DIFF
--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -72,6 +72,12 @@ jobs:
             manifest: oneplus_13.xml
             android_version: android15
             kernel_version: '6.6'
+          - model: OP13-GLO
+            soc: sun
+            branch: oneplus/sm8750
+            manifest: ‎oneplus_13_global.xml
+            android_version: android15
+            kernel_version: '6.6'
           - model: OPAce5Pro
             soc: sun
             branch: oneplus/sm8750


### PR DESCRIPTION
OnePlus recently separated OnePlus 13 China and OnePlus 13 Global/EU/India sources: https://github.com/OnePlusOSS/kernel_manifest/commit/0c41f3041d4b180c87476fcd40e20a47538c4cf7 https://github.com/OnePlusOSS/kernel_manifest/issues/109