### PR TITLE
refactor: flat artifacts via archive:false, skip-decompress, parse zip names

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -1603,6 +1603,7 @@ runs:
         fi
         
         cp "$IMAGE_PATH" "$AK3_FOLDER/Image"
+        mv "${ARTIFACTS_FOLDER}/${OP_MODEL}_${OP_OS_VERSION}.txt" "$AK3_FOLDER/"
         cd "$AK3_FOLDER"
         
         if [ "${{ env.OP_SUSFS }}" = true ]; then
@@ -1624,7 +1625,7 @@ runs:
         
         mv "$ZIP_NAME" "$ARTIFACTS_FOLDER/"
         
-        find "$ARTIFACTS_FOLDER" -maxdepth 1 -type f ! -name "$ZIP_NAME" ! -name "${OP_MODEL}_${OP_OS_VERSION}.txt" -delete
+        find "$ARTIFACTS_FOLDER" -maxdepth 1 -type f ! -name "$ZIP_NAME" -delete
         
         ZIP_SIZE=$(stat -c%s "$ARTIFACTS_FOLDER/$ZIP_NAME")
         ZIP_SHA256=$(sha256sum "$ARTIFACTS_FOLDER/$ZIP_NAME" | awk '{print $1}')
@@ -1690,6 +1691,7 @@ runs:
           else
             echo "ccache: Disabled (clean build)"
           fi
+          echo "Artifact Name: ${{ env.ZIP_NAME }}"
         } | tee summary.txt
         
         {
@@ -1759,13 +1761,15 @@ runs:
           echo "| **Image SHA256** | \`${{ steps.collect_stats.outputs.image_sha256 }}\` |"
           echo "| **Warnings** | ${{ steps.collect_stats.outputs.warnings_count }} |"
           echo "| **Compiler** | \`${CLANG_VERSION:-unknown}\` |"
+          echo "| **Artifact Name** | \`${{ env.ZIP_NAME }}\` |"
         } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Upload Artifacts
       if: success() && steps.create_zip.conclusion == 'success'
       uses: actions/upload-artifact@v7
       with:
-        name: kernel-${{ inputs.ksu_type }}-${{ env.CONFIG }}_${{ env.OP_OS_VERSION }}
-        path: ${{ env.ARTIFACTS_FOLDER }}/
+        name: ${{ env.ZIP_NAME }}
+        path: ${{ env.ARTIFACTS_FOLDER }}/${{ env.ZIP_NAME }}
+        archive: false
         compression-level: 0
         retention-days: 90

--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -560,9 +560,11 @@ jobs:
           git push origin $NEW_TAG
 
       - name: 📥 Download Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ./downloaded-artifacts
+          merge-multiple: true
+          skip-decompress: true
 
       - name: 📝 Generate Device List and Final Release Notes
         id: generate-notes
@@ -572,17 +574,24 @@ jobs:
           # Collect build metadata
           declare -A device_info
           
-          JSON_BUILD_DATA=$(jq -c '.' ./downloaded-artifacts/build-matrix/matrix.json)
+          JSON_BUILD_DATA=$(jq -c '.' ./downloaded-artifacts/matrix.json)
           
-          for file in $(find downloaded-artifacts -name "*.txt" -type f | sort); do
+          for file in $(find downloaded-artifacts -maxdepth 1 -name "*.zip" -type f | sort); do
             if [ -f "$file" ]; then
-              full_model=$(basename "$file" .txt)
-              model=$(echo "$full_model" | sed -E 's/_[^_]*$//')
-              kernel_version=$(sed -n '1p' "$file")
-              os_version=$(sed -n '2p' "$file")
-              ksu_type=$(sed -n '3p' "$file")
-              ksu_ver=$(sed -n '4p' "$file")
-              susfs_ver=$(sed -n '5p' "$file")
+              zipname=$(basename "$file" .zip)
+              rest="${zipname#AK3_}"
+              IFS='_' read -ra parts <<< "$rest"
+              model="${parts[0]}"
+              os_version="${parts[1]}"
+              kernel_version="${parts[2]}"
+              ksu_type="${parts[3]}"
+              ksu_ver="${parts[4]}"
+              if [ "${parts[5]:-}" = "SuSFS" ]; then
+                susfs_ver="${parts[6]:-unknown}"
+              else
+                susfs_ver="none"
+              fi
+              full_model="${model}_${os_version}"
               device_info["$full_model"]="$model|$os_version|$kernel_version|$ksu_type|$ksu_ver|$susfs_ver"
             fi
           done
@@ -860,7 +869,7 @@ jobs:
 
       - name: 📤 Upload Release Assets Dynamically
         run: |
-          for file in ./downloaded-artifacts/*/*.zip; do
+          for file in ./downloaded-artifacts/*.zip; do
             if [ -f "$file" ]; then
               echo "Uploading $file..."
               gh release upload "${{ env.NEW_TAG }}" "$file" --clobber
@@ -877,12 +886,12 @@ jobs:
           ## 🎉 Release Created Successfully
           
           **Tag:** [\`${{ env.NEW_TAG }}\`](${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ env.NEW_TAG }})  
-          **Kernels:** $(find ./downloaded-artifacts -name "*.zip" | wc -l)
+          **Kernels:** $(find ./downloaded-artifacts -maxdepth 1 -name "*.zip" -type f | wc -l)
           
           ### 📦 Assets
           EOF
           
-          for zip in ./downloaded-artifacts/*/*.zip; do
+          for zip in ./downloaded-artifacts/*.zip; do
             if [ -f "$zip" ]; then
               name=$(basename "$zip")
               size=$(stat -c%s "$zip")


### PR DESCRIPTION
Changes in action.yml:
- Create Kernel ZIP: mv metadata txt from ARTIFACTS_FOLDER to AK3_FOLDER before zip creation so it's included in AK3 zip
- find -delete: removed obsolete txt exclusion
- Upload Artifacts: name set to ZIP_NAME, path changed to exact zip file, added archive: false to prevent container wrapping
- Final Build Summary: added Artifact Name row to both GITHUB_STEP_SUMMARY and summary.txt

Changes in build-kernel-release.yml:
- Download Artifacts: replaced download-artifact v4 with v8 using merge-multiple and skip-decompress to get all files flat
- matrix.json path updated from build-matrix/matrix.json to matrix.json (flat)
- Release notes loop: replaced txt-based parsing with zip filename parsing
- Upload assets loop: simplified from */*.zip to *.zip flat
- Release summary: Kernels count and Assets loop updated to use flat *.zip pattern with maxdepth 1