### PR TITLE
Support both old sepolicy and new sepolicy command Structure

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -869,6 +869,8 @@ runs:
               patch -p1 --forward < "$KERNEL_PATCHES_FOLDER/next/susfs_fix_patches/$susfs_version/ksu_toolkit.patch"
               echo "Patching Multi-manager Support for SusFS kernel!"
               patch -p1 --forward < "$KERNEL_PATCHES_FOLDER/next/susfs_fix_patches/$susfs_version/multi_manager.patch"
+              echo "Patching Multi-manager sepolicy Support for SusFS kernel!"
+              patch -p1 --forward < "$KERNEL_PATCHES_FOLDER/next/susfs_fix_patches/$susfs_version/multi_sepolicy_fix.patch"
             else
               cd "$KSU_FOLDER"
               patch -p1 --forward < "$SUSFS_FOLDER/kernel_patches/KernelSU/10_enable_susfs_for_ksu.patch" || true


### PR DESCRIPTION
WildKSU is fully in sync with Magica commit from upstream KSU, which has refactored the way sepolicy is handled.
KernelSU-Next has currently decided not to support Magica and refactor sepolicy at a later date.

This patch bridges the gap between them and allows both ksud sepolicy commands to work as expected. Even old WildKSU manager should work fine.