### PR TITLE
Disable CONFIG_BPF_STREAM_PARSER for all mtk devices.

### DIFF
--- a/.github/actions/action.yml
+++ b/.github/actions/action.yml
@@ -1291,7 +1291,7 @@ runs:
         cd "$COMMON_KERNEL_FOLDER"
         KERNEL_VERSION="${{ env.KERNEL_VER }}"
         
-        if [[ "$KERNEL_VERSION" != "6.12" ]]; then
+        if [[ "$KERNEL_VERSION" != "6.12" ]] && [[ "$OP_BRANCH" != wild/mt* ]]; then
             echo "CONFIG_BPF_STREAM_PARSER=y" >> "$COMMON_KERNEL_FOLDER/arch/arm64/configs/gki_defconfig"
         fi
         


### PR DESCRIPTION
Enabling this causes CRCs to update and fails to load Bluetooth and Wlan.

Symobols CRCs changed:
register_btf_kfunc_id_set
register_btf_fmodret_id_set
register_btf_id_dtor_kfuncs
sk_filter_trim_cap
bpf_prog_create
bpf_prog_create_from_user
bpf_prog_destroy
sk_attach_filter
bpf_redirect_info
xdp_master_redirect
xdp_do_redirect
xdp_do_redirect_frame
ipv6_bpf_stub
xfrm_bpf_md_dst
nfct_btf_struct_access
bpf_warn_invalid_xdp_action
sk_detach_filter
sk_msg_alloc
sk_msg_clone
sk_msg_return_zero
sk_msg_return
sk_msg_free_nocharge
sk_msg_free
sk_msg_free_partial
sk_msg_trim
sk_msg_zerocopy_from_iter
sk_msg_memcopy_from_iter
sk_msg_recvmsg
sk_msg_is_readable
sk_psock_init
sk_psock_drop
sk_psock_msg_verdict
sk_psock_tls_strp_read
sock_map_unhash
sock_map_destroy
sock_map_close
esp_output_head
esp_output_tail
esp_input_done2
tcp_bpf_sendmsg_redir
tcp_bpf_update_proto
udp_bpf_update_proto
esp6_output_head
esp6_output_tail
esp6_input_done2