### PR TITLE
Enhance clone speed by caching toolchain and tarballs

### DIFF
--- a/.github/actions/build-kernel/action.yml
+++ b/.github/actions/build-kernel/action.yml
@@ -42,6 +42,9 @@ inputs:
     required: false
     type: boolean
     default: false
+  github_token:
+    description: 'GitHub Token'
+    required: true
 
 outputs:
   kernel_version:
@@ -298,6 +301,8 @@ runs:
       run: |
         set -euo pipefail
         CONFIG="$OP_MODEL"
+        echo "Creating folder for configuration: $CONFIG"
+        mkdir -p "$CONFIG"
         echo "CONFIG=$CONFIG" >> "$GITHUB_ENV"
         REPO="/usr/local/bin/repo"
         if [ ! -x "$REPO" ]; then
@@ -314,42 +319,13 @@ runs:
         git config --global core.fsmonitor true
         git config --global pack.sparse true
 
-    - name: Initialize and Sync Kernel Source
-      shell: bash
-      run: |
-        set -euo pipefail
-        echo "::group::Initialize kernel source"
-        echo "Creating folder for configuration: $CONFIG"
-        mkdir -p "$CONFIG"
-        cd "$CONFIG"
-        echo "Initializing and syncing kernel source..."
-        
-        if [[ "$OP_MANIFEST" == https://* ]]; then
-          mkdir -p .repo/manifests
-          curl --fail --show-error --location --proto '=https' "$OP_MANIFEST" -o .repo/manifests/temp_manifest.xml
-          "$REPO" init -u https://github.com/OnePlusOSS/kernel_manifest.git -b "oneplus/sm8650" -m temp_manifest.xml --repo-rev=v2.16 --depth=1 --no-clone-bundle --no-tags
-        elif [[ "$OP_BRANCH" == wild/* ]]; then
-          mkdir -p .repo/manifests
-          cp "../manifests/$(echo "$OP_OS_VERSION" | tr '[:upper:]' '[:lower:]')/$OP_MANIFEST" .repo/manifests/temp_manifest.xml
-          "$REPO" init -u https://github.com/OnePlusOSS/kernel_manifest.git -b "oneplus/sm8650" -m temp_manifest.xml --repo-rev=v2.16 --depth=1 --no-clone-bundle --no-tags
-        else
-          "$REPO" init -u https://github.com/OnePlusOSS/kernel_manifest.git -b "$OP_BRANCH" -m "$OP_MANIFEST" --repo-rev=v2.16 --depth=1 --no-clone-bundle --no-tags
-        fi
-        
-        "$REPO" --version
-        success=false
-        for i in 1 2 3; do
-          if "$REPO" sync -c --no-clone-bundle --no-tags --optimized-fetch \
-             -j"$(nproc --all)" --fail-fast; then
-            success=true
-            break
-          fi
-          echo "⚠️ repo sync attempt $i failed; retrying..."
-          sleep 30
-        done
-        $success || { echo "::error::repo sync failed after 3 attempts"; exit 1; }
-        echo "✅ Kernel source synced"
-        echo "::endgroup::"
+    - name: Sync Kernel Source
+      id: sync-kernel-source
+      uses: ./.github/actions/kernel-source-sync
+      with:
+        source_location: ${{ env.CONFIG }}
+        github_token: ${{ inputs.github_token }}
+        debug: ${{ inputs.debug }}
 
     - name: Set Dir Paths
       shell: bash

--- a/.github/actions/kernel-source-sync/action.yml
+++ b/.github/actions/kernel-source-sync/action.yml
@@ -1,0 +1,228 @@
+name: 'Download and configure Kernel Source code'
+
+inputs:
+  source_location:
+    description: 'Folder path to save Kernel source'
+    required: true
+    type: string
+  github_token:
+    description: 'GitHub Token'
+    required: true
+  debug:
+    description: 'Enable Logs'
+    required: false
+    type: boolean
+    default: false
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Download and Prepare Manifest
+      shell: bash
+      working-directory: ${{ inputs.source_location }}
+      run: |
+        # Download and Prepare Manifest
+        if [[ "$OP_MANIFEST" == https://* ]]; then
+          curl --fail --show-error --location --proto '=https' "$OP_MANIFEST" -o manifest.xml
+        elif [[ "$OP_BRANCH" == wild/* ]]; then
+          cp "../manifests/$(echo "$OP_OS_VERSION" | tr '[:upper:]' '[:lower:]')/$OP_MANIFEST" manifest.xml
+        else
+          curl --fail --show-error --location --proto '=https' "https://raw.githubusercontent.com/OnePlusOSS/kernel_manifest/refs/heads/$OP_BRANCH/$OP_MANIFEST" -o manifest.xml
+        fi
+
+    - name: Download Manifest Archives
+      shell: python
+      env:
+        PYTHONUNBUFFERED: "1"
+        GITHUB_TOKEN: ${{ inputs.github_token }}
+        DEBUG: ${{ inputs.debug }}
+      working-directory: ${{ inputs.source_location }}
+      run: |
+        # Download Manifest Archives
+        import xml.etree.ElementTree as ET
+        import subprocess
+        import os, shutil
+        import time
+        import glob
+        from concurrent.futures import ThreadPoolExecutor
+        import requests
+        
+        MAX_WORKERS = (os.cpu_count() or 2) * 4
+        NPROC = int(subprocess.check_output("nproc", shell=True).strip())
+        TARGET_REPO = "${{ github.repository }}"
+        TOOLCHAIN_KEYWORDS = ["clang", "rust"]
+        DEBUG = os.environ.get("DEBUG", "false").lower() == "true"
+        aria_quiet_flags = "--quiet --summary-interval=0" if not DEBUG else ""
+        
+        print("::group::Download Manifest Archives")
+        
+        def get_release_parts(label, rev):
+            url = f"https://api.github.com/repos/{TARGET_REPO}/releases"
+            headers = {
+                "Authorization": f"token {os.environ['GITHUB_TOKEN']}",
+                "Accept": "application/vnd.github.v3+json"
+            }
+            
+            for attempt in range(3):
+                try:
+                    response = requests.get(url, headers=headers)
+                    response.raise_for_status()
+                    releases = response.json()
+                    release = next((r for r in releases if r['name'] == "Toolchains Mirror Cache" or r['tag_name'] == "toolchain-cache"), None)
+                    if not release: return []
+                    
+                    prefix = f"{label}-{rev}.tar.gz"
+                    return [(a['name'], a['url']) for a in release['assets'] if a['name'].startswith(prefix)]
+                except Exception as e:
+                    print(f"  [RETRY {attempt+1}] API failed: {e}")
+                    time.sleep(2)
+            return []
+        
+        def sync_project(task):
+            name, path, url, strip, rev = task
+            if path not in ["./", "."]:
+                os.makedirs(path, exist_ok=True)
+            
+            headers = (
+                "-H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36' "
+                "-H 'Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8' "
+                "-H 'Accept-Encoding: gzip, deflate, br' "
+                "-H 'Connection: keep-alive' "
+                "--tcp-fastopen"
+            )
+            
+            print(f"Syncing: {name} -> {path}")
+            start_time = time.time()
+            print(f"  [PENDING] {name}")
+            try:
+                match = next((x for x in TOOLCHAIN_KEYWORDS if x in name.lower()), None)
+                if match:
+                    label = match
+                    base_filename = f"{label}-{rev}.tar.gz"
+                    
+                    asset_data = get_release_parts(label, rev)
+                    
+                    if not asset_data:
+                        print(f"  [ERROR] No assets found for {base_filename} in release!")
+                        return False
+                    
+                    if DEBUG:
+                        print(f"  [CACHE] Fetching {label} toolchain: {base_filename}...")
+                    
+                    for asset_name, api_url in asset_data:
+                        aria_cmd = (
+                            f"aria2c -x16 -s16 -k1M --file-allocation=none {aria_quiet_flags} "
+                            f"--header='Authorization: token {os.environ['GITHUB_TOKEN']}' "
+                            f"--header='Accept: application/octet-stream' "
+                            f"-o {asset_name} {api_url}"
+                        )
+                        subprocess.run(aria_cmd, shell=True, check=True, capture_output=not DEBUG)
+                    
+                    parts = sorted(glob.glob(f"{base_filename}.part*"))
+                    if parts:
+                        if DEBUG:
+                            print(f"  [MERGE] Combining {len(parts)} parts for {rev}...")
+                        subprocess.run(f"cat {base_filename}.part* | tar -I 'pigz -p {NPROC} -b 256' -x --record-size=1M --no-same-owner --no-same-permissions -C {path} {strip}", shell=True, check=True)
+                        subprocess.run(f"rm {base_filename}.part*", shell=True, check=True)
+                    else:
+                        if os.path.exists(base_filename):
+                            if DEBUG:
+                                print(f"  [EXTRACT] Single file detected...")
+                            subprocess.run(f"tar -I 'pigz -p {NPROC} -b 256' -x --record-size=1M --no-same-owner --no-same-permissions -f {base_filename} -C {path} {strip}", shell=True, check=True)
+                            os.remove(base_filename)
+                        else:
+                            print(f"  [ERROR] {base_filename} missing after download!")
+                            return False
+                else:
+                    cmd = f"curl -LfsS {headers} --retry 5 --connect-timeout 30 '{url}' | tar -I 'pigz -p {NPROC} -b 256' -x --record-size=1M -C {path} {strip}"
+                    subprocess.run(cmd, shell=True, check=True)
+                
+                duration = time.time() - start_time
+                print(f"Synced {name} successfully! ({duration:.2f}s)")
+                return True
+            except subprocess.CalledProcessError as e:
+                print(f"  [ERROR] Command failed for {name}: {e.cmd}")
+                print(f"   Stderr: {e.stderr.decode() if e.stderr else 'No stderr'}")
+                return False
+            except Exception as e:
+                print(f"  [ERROR] Failed to sync {name}")
+                return False
+        
+        global_start = time.time()
+        
+        with open('manifest.xml', 'r') as f:
+            manifest_content = f.read()
+        
+        root = ET.fromstring(manifest_content)
+        top_dir = os.getcwd()
+        
+        remotes = {r.get('name'): r.get('fetch').rstrip('/') for r in root.findall('remote')}
+        default = root.find('default')
+        def_remote = default.get('remote') if default is not None else None
+        def_rev = default.get('revision') if default is not None else None
+        
+        sync_tasks = []
+        post_process_data = []
+        
+        for project in root.findall('project'):
+            name = project.get('name')
+            path = project.get('path', name)
+            remote_name = project.get('remote', def_remote)
+            rev = project.get('revision', def_rev)
+            base_url = remotes.get(remote_name)
+            
+            if not base_url: continue
+            
+            if "github.com" in base_url:
+                url = f"{base_url}/{name}/archive/{rev}.tar.gz"
+                strip = "--strip-components=1"
+            elif "googlesource.com" in base_url:
+                url = f"{base_url}/{name}/+archive/{rev}.tar.gz"
+                strip = ""
+            elif "git.codelinaro.org" in base_url:
+                url = f"{base_url}/{name}/-/archive/{rev}.tar.gz"
+                strip = "--strip-components=1"
+            else:
+                continue
+            
+            sync_tasks.append((name, path, url, strip, rev))
+            
+            for child in project:
+                if child.tag in ['linkfile', 'copyfile']:
+                    post_process_data.append((path, child))
+        
+        if DEBUG:
+            print(f"Starting parallel sync of {len(sync_tasks)} projects...")
+        with ThreadPoolExecutor(max_workers=MAX_WORKERS) as executor:
+            success_list = list(executor.map(sync_project, sync_tasks))
+            
+            if not all(success_list):
+                print("::error::One or more projects failed to sync!")
+                print("::endgroup::")
+                exit(1)
+        
+        print("Processing linkfiles and copyfiles...")
+        for path, child in post_process_data:
+            src_rel = child.get('src')
+            dest_rel = child.get('dest')
+            if not src_rel or not dest_rel: continue
+            
+            src_path = os.path.join(top_dir, path, src_rel)
+            dest_path = os.path.join(top_dir, dest_rel)
+            os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+            
+            if child.tag == 'linkfile':
+                if os.path.lexists(dest_path): os.remove(dest_path)
+                rel_target = os.path.relpath(src_path, os.path.dirname(dest_path))
+                os.symlink(rel_target, dest_path)
+                print(f"  [Link] {dest_rel} -> {src_rel}")
+            elif child.tag == 'copyfile':
+                shutil.copy2(src_path, dest_path)
+                print(f"  [Copy] {dest_rel} from {src_rel}")
+        
+        
+        total_duration = time.time() - global_start
+        minutes = int(total_duration // 60)
+        seconds = total_duration % 60
+        print(f"Kernel Sync completed in {minutes}m {seconds:.2f}s")
+        print("::endgroup::")

--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -49,6 +49,11 @@ on:
         required: false
         type: boolean
         default: false
+      mirror_toolchains:
+        description: 'Do you want to sync toolchains before build? [99% runs not required]'
+        required: false
+        type: boolean
+        default: false
       build_timestamp:
         description: 'Custom kernel build timestamp for uname -a (e.g. "Tue Feb 10 10:01:02 UTC 2026"). Leave empty for current time.'
         type: string
@@ -56,11 +61,11 @@ on:
       android12-5_10_susfs_branch_or_commit:
         description: 'Enter SusFS Branch or commit hash for android12-5.10'
         type: string
-        default: ''      
+        default: ''
       android13-5_15_susfs_branch_or_commit:
         description: 'Enter SusFS Branch or commit hash for android13-5.15'
         type: string
-        default: ''      
+        default: ''
       android14-6_1_susfs_branch_or_commit:
         description: 'Enter SusFS Branch or commit hash for android14-6.1'
         type: string
@@ -465,6 +470,7 @@ jobs:
           - Clean Build/No Ccache: ${{ inputs.clean_build && '✅ Yes' || '❌ No' }}
           - Create Release: ${{ inputs.make_release && '✅ Yes' || '❌ No' }}
           - Create Debug Artifacts: ${{ inputs.debug && '✅ Yes' || '❌ No' }}
+          - Sync toolchains: ${{ inputs.mirror_toolchains && '✅ Yes' || '❌ No' }}
           
           **SUSFS Configuration:**
           EOF
@@ -515,10 +521,17 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "> **⚠️ Android-Kernel Filter:** Only OOS15 and OOS16 devices will be built for \`${{ inputs.op_model }}\`" >> $GITHUB_STEP_SUMMARY
           fi
-          
+
+  mirror_toolchain:
+    needs: set-op-model
+    if: ${{ inputs.mirror_toolchains }}
+    uses: ./.github/workflows/mirror-toolchains.yml
+    secrets: inherit
+
   build:
     name: build (${{ matrix.model }}, ${{ matrix.soc }}, ${{ matrix.branch }}, ${{ matrix.manifest }}, ${{ matrix.android_version }}, ${{ matrix.kernel_version }}, ${{ matrix.os_version }}, ${{ matrix.ksu_type }})
-    needs: set-op-model
+    needs: [set-op-model, mirror_toolchain]
+    if: always() && needs.set-op-model.result == 'success' && (needs.mirror_toolchain.result == 'success' || needs.mirror_toolchain.result == 'skipped')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -571,7 +584,7 @@ jobs:
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
             git curl ca-certificates build-essential clang lld flex bison \
             libelf-dev libssl-dev libncurses-dev zlib1g-dev liblz4-tool \
-            libxml2-utils rsync unzip dwarves file python3 ccache jq bc dos2unix kmod libdw-dev elfutils
+            libxml2-utils rsync unzip dwarves file python3 ccache jq bc dos2unix kmod libdw-dev elfutils pigz
           sudo apt-get clean
           echo "✅ Dependencies installed"
           echo "::endgroup::"
@@ -604,7 +617,7 @@ jobs:
 
       - name: 🔨 Build Kernel
         id: build
-        uses: ./.github/actions
+        uses: ./.github/actions/build-kernel
         with:
           op_config_json: ${{ steps.prepare_config.outputs.config_json }}
           ksu_type: ${{ matrix.ksu_type }}
@@ -614,6 +627,7 @@ jobs:
           build_timestamp: ${{ inputs.build_timestamp }}
           clean: ${{ inputs.clean_build }}
           debug: ${{ inputs.debug }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: 📊 Build statistics
         id: build-stat

--- a/.github/workflows/mirror-toolchains.yml
+++ b/.github/workflows/mirror-toolchains.yml
@@ -1,0 +1,162 @@
+name: Mirror static toolchains to GitHub Release
+
+permissions:
+  contents: write
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure Single Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Check if the release already exists
+          if ! gh release view "toolchain-cache" --repo "fatalcoder524/OnePlus_KernelSU_SUSFS" >/dev/null 2>&1; then
+            echo "Release not found. Creating..."
+            gh release create "toolchain-cache" \
+              --title "Toolchains Mirror Cache" \
+              --notes "Deduplicated Toolchains" \
+              --draft \
+              --repo "fatalcoder524/OnePlus_KernelSU_SUSFS"
+          else
+            echo "Release 'toolchain-cache' already exists. Skipping creation."
+          fi
+
+  generate-mirror-matrix:
+    runs-on: ubuntu-latest
+    needs: prepare-release
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      - name: Generate Mirror Matrix
+        id: generate-config
+        shell: bash
+        run: |
+          set -euo pipefail
+          
+          echo "[" > all_configs.json
+          mapfile -t files < <(find configs/ -name "*.json")
+          for i in "${!files[@]}"; do
+            cat "${files[$i]}" >> all_configs.json
+            [[ $((i+1)) -lt ${#files[@]} ]] && echo "," >> all_configs.json
+          done
+          echo "]" >> all_configs.json
+
+      - name: Resolve Unique Projects
+        id: set-matrix
+        shell: python
+        env:
+          PYTHONUNBUFFERED: "1"
+        run: |
+          import xml.etree.ElementTree as ET
+          import json
+          import os
+          import subprocess
+          import shutil
+          
+          with open('all_configs.json', 'r') as f:
+              configs = json.load(f)
+          
+          unique_toolchains = {}
+          TOOLCHAIN_KEYWORDS = ["clang", "rust"]
+          
+          print(f"Processing {len(configs)} configurations...")
+          print("-" * 50)
+          
+          for cfg in configs:
+              op_model = cfg.get('model', 'Unknown')
+              op_branch = cfg.get('branch', '')
+              op_manifest = cfg.get('manifest', '')
+              op_os_version = cfg.get('os_version', '').lower()
+              
+              xml_file = "temp_manifest.xml"
+              
+              try:
+                  if op_manifest.startswith("https://"):
+                      subprocess.run(f"curl -LfsS {op_manifest} -o {xml_file}", shell=True, check=True)
+                  elif op_branch.startswith("wild/"):
+                      shutil.copy(f"manifests/{op_os_version}/{op_manifest}", xml_file)
+                  else:
+                      url = f"https://raw.githubusercontent.com/OnePlusOSS/kernel_manifest/refs/heads/{op_branch}/{op_manifest}"
+                      subprocess.run(f"curl -LfsS {url} -o {xml_file}", shell=True, check=True)
+                  
+                  root = ET.parse(xml_file).getroot()
+                  remotes = {r.get('name'): r.get('fetch').rstrip('/') for r in root.findall('remote')}
+                  default = root.find('default')
+                  def_remote = default.get('remote')
+                  def_rev = default.get('revision')
+                  
+                  for project in root.findall('project'):
+                      name = project.get('name')
+                      match = next((x for x in TOOLCHAIN_KEYWORDS if x in name.lower()), None)
+                      
+                      if match:
+                        type_label = match
+                        remote_name = project.get('remote', def_remote)
+                        rev = project.get('revision', def_rev)
+                        base_url = remotes.get(remote_name, "")
+                        cache_filename = f"{type_label}-{rev}.tar.gz"
+                        
+                        if cache_filename not in unique_toolchains and ("git.codelinaro.org" in base_url or "googlesource.com" in base_url):
+                            if "googlesource.com" in base_url:
+                                dl_url = f"{base_url}/{name}/+archive/{rev}.tar.gz"
+                            else:
+                                dl_url = f"{base_url}/{name}/-/archive/{rev}.tar.gz"
+                            unique_toolchains[cache_filename] = {"rev": rev, "url": dl_url, "name": name, "type_label": type_label, "cache_file": cache_filename}
+                            print(f"🆕 [{op_model}][{op_os_version}] -> New {type_label} found: {rev}")
+                        else:
+                            print(f"♻️ [{op_model}][{op_os_version}] -> Using existing {type_label}: {rev}")
+              except Exception as e:
+                  print(f"⚠️ Failed to process {op_manifest}: {e}")
+          matrix = {"include": list(unique_toolchains.values())}
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f"matrix={json.dumps(matrix)}\n")
+          print(f"✅ Found {len(unique_toolchains)} unique projects to mirror.")
+
+  mirror-to-release:
+    needs: [prepare-release, generate-mirror-matrix]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix: ${{ fromJSON(needs.generate-mirror-matrix.outputs.matrix) }}
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Sync & Upload
+        run: |
+          TARGET_REPO="${{ github.repository }}"
+          REV="${{ matrix.rev }}"
+          FILENAME="${{ matrix.cache_file }}"
+          
+          EXISTING_ASSETS=$(gh release view "toolchain-cache" --repo "$TARGET_REPO" --json assets --jq ".assets[].name")
+          
+          if ! echo "$EXISTING_ASSETS" | grep -q "^${FILENAME}$" && ! echo "$EXISTING_ASSETS" | grep -q "^${FILENAME}.partaa$"; then
+            echo "📥 Downloading ${{ matrix.type_label }} from ${{ matrix.url }}..."
+            curl -LfsS -# -H 'User-Agent: Mozilla/5.0' --tcp-fastopen -o "$FILENAME" "${{ matrix.url }}"
+            
+            FILE_SIZE=$(stat -c%s "$FILENAME")
+            MAX_SIZE=2000000000 # ~1.86GB
+            
+            if [ "$FILE_SIZE" -gt "$MAX_SIZE" ]; then
+              echo "⚠️ File is > 2GB $FILE_SIZE bytes. Splitting..."
+              split -b 1500M "$FILENAME" "${FILENAME}.part"
+              
+              for part in "${FILENAME}".part*; do
+                echo "📤 Uploading $part..."
+                gh release upload "toolchain-cache" "$part" --clobber --repo "$TARGET_REPO"
+              done
+            else
+              echo "📤 Uploading single file..."
+              gh release upload "toolchain-cache" "$FILENAME" --clobber --repo "$TARGET_REPO"
+            fi
+          else
+            echo "✅ ${{ matrix.type_label }} revision ${{ matrix.rev }} already cached."
+          fi


### PR DESCRIPTION
- Replace Repo tool with custom python implementation
- Cache static toolchains such as clang and rust uniquely in Github Releases to bypass cache restrictions
- Use pre-cached toochains and tarballs to maximise setup speed and reduce clone and build time
- Add a workflow to pre-cache toolchains