### PR TITLE
remove debug warning

### DIFF
--- a/.github/actions/build-kernel/action.yml
+++ b/.github/actions/build-kernel/action.yml
@@ -1979,7 +1979,7 @@ runs:
         } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Upload Debug Artifacts
-      if: ${{ always() && !cancelled() && inputs.debug }}
+      if: ${{ always() && !cancelled() && inputs.debug == 'true' }}
       uses: actions/upload-artifact@v7
       with:
         name: ${{ env.DEBUG_ZIP_NAME }}


### PR DESCRIPTION
just to remove the warning when nit running with debug option option : 
"[build (OP10pro, waipio, wild/sm8450, oneplus_10_pro_u.xml, android12, 5.10, OOS14, KSUN)](https://github.com/WildKernels/OnePlus_KernelSU_SUSFS/actions/runs/24944580207/job/73043706398#step:7:9370)
No files were found with the provided path: /home/runner/work/OnePlus_KernelSU_SUSFS/OnePlus_KernelSU_SUSFS/debug_artifacts. No artifacts will be uploaded."