### PR TITLE
fix(ci): prevent trigger-release from being skipped due to upstream s…

### DIFF
--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -790,9 +790,10 @@ jobs:
     needs: [set-op-model, build]
     runs-on: ubuntu-latest
     if: |
-      !cancelled() && 
-      needs.build.result == 'success' && 
-      inputs.make_release == true
+      !cancelled() &&
+      inputs.make_release == true &&
+      needs.build.result == 'success' &&
+      needs.set-op-model.result == 'success'
     env:
       REPO_OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}

--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -790,7 +790,7 @@ jobs:
     needs: [set-op-model, build]
     runs-on: ubuntu-latest
     if: |
-      always() && 
+      !cancelled() && 
       needs.build.result == 'success' && 
       inputs.make_release == true
     env:

--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -789,7 +789,10 @@ jobs:
   trigger-release:
     needs: [set-op-model, build]
     runs-on: ubuntu-latest
-    if: ${{ inputs.make_release }}
+    if: |
+      always() && 
+      needs.build.result == 'success' && 
+      inputs.make_release == true
     env:
       REPO_OWNER: ${{ github.repository_owner }}
       REPO_NAME: ${{ github.event.repository.name }}


### PR DESCRIPTION
…kip propagation

The trigger-release job was being skipped whenever mirror_toolchain was not  selected, even if all build matrix jobs succeeded. 

This occurred because GitHub Actions' default success() function (implicitly  called in job-level 'if' conditions) returns false if any upstream dependency  in the DAG (like mirror_toolchain) is skipped.

This commit fixes the issue by:
1. Using always() to override the default status check.
2. Explicitly checking that the build job's result is 'success'.
3. Validating the make_release input.

This ensures releases are correctly triggered regardless of whether  toolchain mirroring was performed.