### PR TITLE
fix: fix release table for devices with versioned model names

### DIFF
--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -859,7 +859,7 @@ jobs:
               else
                 susfs_ver="none"
               fi
-              full_model="${model}_${os_version}"
+              full_model="${model}_${os_version}_${kernel_version}"
               device_info["$full_model"]="$model|$os_version|$kernel_version|$ksu_type|$ksu_ver|$susfs_ver"
             fi
           done
@@ -902,10 +902,15 @@ jobs:
           for full_key in $(printf '%s\n' "${!device_info[@]}" | sort); do
             IFS='|' read -r model os_ver kernel_ver _ _ _ <<< "${device_info[$full_key]}"
             
-            # Use jq to extract feature flags for this model from the JSON matrix
-            feature_flags=$(jq -r --arg MODEL "$model" '
-              .[] | 
-              select(.model == $MODEL) |
+            # Use jq to extract feature flags for this model from the JSON matrix.
+            # Reconstruct the original model name (e.g. OP13r-6.1.118) in case the ZIP
+            # had the kernel version suffix stripped for display. Try exact ORIG_MODEL
+            # first, fall back to base MODEL, both filtered by os_version.
+            full_kv=$(echo "$kernel_ver" | sed 's/^[^-]*-//')
+            possible_orig_model="${model}-${full_kv}"
+            feature_flags=$(jq -r --arg MODEL "$model" --arg ORIG_MODEL "$possible_orig_model" --arg OS "$os_ver" '
+              ([ .[] | select(.model == $ORIG_MODEL and .os_version == $OS) ][0]) //
+              ([ .[] | select(.model == $MODEL      and .os_version == $OS) ][0]) |
               "\(.hmbird // false)\t\(.susfs // false)\t\(.bbr // false)\t\(.bbg // false)\t\(.ttl // false)\t\(.ip_set // false)\t\(.unicode // false)\t\(.ds // false)\t\(.ntsync // false)"
             ' <<< "$JSON_BUILD_DATA")
             


### PR DESCRIPTION
Two bugs when multiple kernel versions of the same device are built:
1. device_info key collision: "OP13r_OOS16" was shared by both android14-6.1.118 and android14-6.1.141, causing one to be dropped.
2. jq feature lookup failed for versioned models: ZIP shows "OP13r" but matrix.json has "OP13r-6.1.118", so select(.model == $MODEL) found no match and features showed N/A.

Fix 1: include kernel_version in device_info key.
Fix 2: reconstruct possible original model name from kernel version suffix (e.g. OP13r + 6.1.118 -> OP13r-6.1.118), try exact match first, fall back to base model, both filtered by os_version.