### PR TITLE
ci: download ccache once via setup job + artifact (fix parallel 504 throttling)

### DIFF
--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -551,7 +551,6 @@ jobs:
             sleep $(( attempt * 5 + RANDOM % 6 ))
           done
           if [ "$ok" = 1 ]; then
-            chmod +x ccache
             echo "✅ downloaded ccache once for all matrix jobs"
           else
             echo "::warning::custom ccache download failed; matrix jobs will fall back to the apt ccache"

--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -528,9 +528,47 @@ jobs:
     uses: ./.github/workflows/mirror-toolchains.yml
     secrets: inherit
 
+  prepare_ccache:
+    name: Prepare ccache binary (download once)
+    runs-on: ubuntu-latest
+    steps:
+      # Download the custom ccache binary ONCE for the whole matrix and share it as
+      # an artifact. Previously every parallel matrix job curl'd the same GitHub raw
+      # URL simultaneously, which made GitHub's edge rate-limit / 504 the CI IPs and
+      # fail the whole build (the URL is fine in a browser -- it's the ~30x parallel
+      # hammering that triggers the throttle).
+      - name: Download custom ccache once
+        run: |
+          set -uo pipefail
+          echo "::group::Download ccache"
+          url="https://raw.githubusercontent.com/WildKernels/kernel_patches/refs/heads/main/ccache/ccache-x86-64"
+          ok=0
+          for attempt in 1 2 3 4 5 6; do
+            if curl -LfsS --connect-timeout 30 --max-time 120 -H "User-Agent: Mozilla/5.0" "$url" -o ccache && [ -s ccache ]; then
+              ok=1; break
+            fi
+            echo "attempt $attempt failed (GitHub raw 504/throttle); backing off..."
+            sleep $(( attempt * 5 + RANDOM % 6 ))
+          done
+          if [ "$ok" = 1 ]; then
+            chmod +x ccache
+            echo "✅ downloaded ccache once for all matrix jobs"
+          else
+            echo "::warning::custom ccache download failed; matrix jobs will fall back to the apt ccache"
+            rm -f ccache
+          fi
+          echo "::endgroup::"
+      - name: Upload ccache artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ccache-binary
+          path: ccache
+          retention-days: 1
+          if-no-files-found: warn
+
   build:
     name: build (${{ matrix.model }}, ${{ matrix.soc }}, ${{ matrix.branch }}, ${{ matrix.manifest }}, ${{ matrix.android_version }}, ${{ matrix.kernel_version }}, ${{ matrix.os_version }}, ${{ matrix.ksu_type }})
-    needs: [set-op-model, mirror_toolchain]
+    needs: [set-op-model, mirror_toolchain, prepare_ccache]
     if: |
       !cancelled() &&
       needs.set-op-model.result == 'success' &&
@@ -565,17 +603,28 @@ jobs:
           echo "✅ Dependencies installed"
           echo "::endgroup::"
 
-      - name: Install ccache with ECS by cctv18
+      - name: Get prebuilt ccache (downloaded once by prepare_ccache)
+        uses: actions/download-artifact@v4
+        with:
+          name: ccache-binary
+          path: ccache-dl
+        continue-on-error: true
+
+      - name: Install ccache (ECS by cctv18, shared via artifact)
         run: |
-          # Install ccache with ECS by cctv18
-          set -euo pipefail
-          echo "::group::Install ccache with ECS"
-          curl -LfsS --retry 5 --retry-delay 5 --retry-all-errors --connect-timeout 30 --tcp-fastopen -H "User-Agent: Mozilla/5.0" "https://github.com/WildKernels/kernel_patches/raw/refs/heads/main/ccache/ccache-x86-64" -o ccache
-          sudo cp -f ./ccache /usr/bin/ccache
-          sudo chmod +x /usr/bin/ccache
-          rm -f ./ccache
-          
-          echo "[DEBUG] Ccache version : $(ccache --version)"
+          set -uo pipefail
+          echo "::group::Install ccache"
+          if [ -s ccache-dl/ccache ]; then
+            sudo cp -f ccache-dl/ccache /usr/bin/ccache
+            sudo chmod +x /usr/bin/ccache
+            echo "✅ installed custom ccache from shared artifact"
+          else
+            # prepare_ccache could not fetch it (504/throttle); keep the apt ccache
+            # already installed in 'Install Minimal Dependencies'.
+            echo "::warning::shared ccache artifact unavailable; using apt ccache"
+          fi
+          rm -rf ccache-dl
+          echo "[DEBUG] Ccache version : $(ccache --version | head -1)"
           echo "::endgroup::"
 
       - name: ♻️ Configure ccache & LTO cache (bounded)

--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -559,7 +559,7 @@ jobs:
           fi
           echo "::endgroup::"
       - name: Upload ccache artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ccache-binary
           path: ccache

--- a/.github/workflows/build-kernel-release.yml
+++ b/.github/workflows/build-kernel-release.yml
@@ -604,7 +604,7 @@ jobs:
           echo "::endgroup::"
 
       - name: Get prebuilt ccache (downloaded once by prepare_ccache)
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: ccache-binary
           path: ccache-dl


### PR DESCRIPTION
## Problem
Every matrix `build` job runs **Install ccache with ECS by cctv18**, which curls the same GitHub raw URL:
```
https://github.com/WildKernels/kernel_patches/raw/refs/heads/main/ccache/ccache-x86-64
```
With ~30 device jobs starting in parallel, they all hit that URL at the same moment. GitHub's edge then rate-limits the CI IPs and returns repeated **HTTP 504**, which fails the whole build matrix. The URL itself is fine (downloads instantly in a browser) — it's the simultaneous parallel hammering that trips the throttle. The existing in-step `--retry 5 --retry-delay 5` fires in lockstep across all jobs, so they stay throttled together and all fail.

Observed in a run: 6× `curl: (22) The requested URL returned error: 504` (initial + 5 retries), then the step fails under `set -e`.

## Fix
- Add a `prepare_ccache` job that downloads the binary **once** (retries with jittered backoff) and shares it as an artifact.
- `build` jobs `actions/download-artifact` it instead of each hitting the URL — so the raw URL is touched exactly once per run.
- If the single download still fails, build jobs fall back to the apt `ccache` already installed in **Install Minimal Dependencies** (so the step can never hard-fail the matrix).

Only `.github/workflows/build-kernel-release.yml` is changed.

## Validation
Verified on a fork run with the identical change: `prepare_ccache` ✅ downloaded once + uploaded the artifact, and every `build` job's *Get prebuilt ccache* + *Install ccache* steps ✅ succeeded from the shared artifact.