### PR TITLE
Skip ccache persistence for clean builds

### DIFF
--- a/.github/actions/build-kernel/action.yml
+++ b/.github/actions/build-kernel/action.yml
@@ -2426,7 +2426,7 @@ runs:
         fetch-depth: 1
 
     - name: Save ccache cache
-      if: always() && steps.build_kernel_step.conclusion == 'success'
+      if: always() && steps.build_kernel_step.conclusion == 'success' && (inputs.clean == false || inputs.clean == 'false')
       uses: ./action-source/.github/actions/cache/save
       with:
         cache_path: ${{ env.CCACHE_DIR }}


### PR DESCRIPTION
Skip ccache persistence when `clean_build` is enabled.

Clean builds intentionally do not use ccache, so persisting it is unnecessary. A cache-backend failure after a successful package build should not turn the workflow red.

This applies to every device target and KernelSU variant.